### PR TITLE
Uboot image fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,8 @@ COPY --from=u-boot /u-boot/idbloader.img /
 COPY --from=u-boot /u-boot/spl/u-boot-spl.bin /
 COPY --from=u-boot /u-boot/u-boot.itb /
 
+# Note: we write u-boot.itb twice, because on SD card
+# it will be searched for at block 16384
 RUN \
     cat idbloader.img > newidb.img && \
     cat u-boot-spl.bin >> newidb.img && \
@@ -141,5 +143,5 @@ RUN \
     cat u-boot.itb >> newidb.img && \
     dd if=/dev/zero of=zero32k.bin bs=32768 count=1 && \
     cat zero32k.bin > idb_finish.img && \
-    cat newidb.img >> idb_finish.img
-
+    cat newidb.img >> idb_finish.img && \
+    dd if=u-boot.itb of=idb_finish.img bs=512 seek=16384

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ EOF
 
 RUN cat .config_extra | sed 's|=.*|=|' | xargs -I{} sed -i 's|{}.*||' .config
 
-RUN cat .config_extra >> config
+RUN cat .config_extra >> .config
 
 RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
 &spi0 {

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,7 @@ RUN apt update && \
         swig \
         libssl-dev \
         bc \
-        vim \
-        less \
-        tmux
+        device-tree-compiler
 
 ###############################################################################
 
@@ -44,11 +42,12 @@ RUN git checkout v2.3 && \
 
 FROM toolchain as u-boot
 
-RUN git clone --depth 1 https://source.denx.de/u-boot/u-boot.git
-
+RUN git clone https://source.denx.de/u-boot/u-boot.git
+ 
 WORKDIR /u-boot
-
-RUN make nanopi-r2s-rk3328_defconfig
+ 
+RUN git checkout v2023.01 && \
+    make nanopi-r2s-rk3328_defconfig
 
 RUN <<EOF cat >> .config_extra
 CONFIG_ROCKCHIP_EFUSE=y

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ EOF
 
 RUN sed -i 's|[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|[BROM_BOOTSOURCE_SPINOR] "/spi@ff190000", [BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|' arch/arm/mach-rockchip/rk3328/rk3328.c
 
-RUN sed -i 's|uclass_get_device_by_of_offset(UCLASS_SPI_FLASH|uclass_get_device_by_of_offset(UCLASS_SPI_FLASH|' arch/arm/mach-rockchip/spl-boot-order.c
+RUN sed -i 's|uclass_get_device_by_of_offset(UCLASS_SPI_FLASH|uclass_get_device_by_of_offset(UCLASS_SPI|g' arch/arm/mach-rockchip/spl-boot-order.c
 
 COPY --from=trust /arm-trusted-firmware/build/rk3328/release/bl31/bl31.elf /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,14 @@ RUN BL31=/bl31.elf make CROSS_COMPILE=aarch64-linux-gnu- all -j4
 
 RUN ./tools/mkimage -n rk3328 -T rksd -d tpl/u-boot-tpl.bin idbloader.img
 
+# Uncomment this to enable debug logging in U-Boot final stage:
+#RUN <<EOF cat >> .config
+#CONFIG_LOG=y
+#CONFIG_LOGLEVEL=10
+#EOF
+#COPY uboot_debug.patch /uboot_debug.patch
+#RUN patch -p1 < /uboot_debug.patch
+
 RUN make CROSS_COMPILE=aarch64-linux-gnu- u-boot.itb
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s.dts
 EOF
 
 RUN <<EOF cat >> drivers/spi/rk_spi.c
-DM_DRIVER_ALIAS(rockchip_rk3288_spi, rockchip_rk3328_spi);
+DM_DRIVER_ALIAS(rockchip_rk3288_spi, rockchip_rk3328_spi)
 EOF
 
 RUN sed -i.bak 's|\[BROM_BOOTSOURCE_EMMC\] = "/mmc@ff520000",|[BROM_BOOTSOURCE_SPINOR] "/spi@ff190000", [BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN git checkout v2.3 && \
 FROM toolchain as u-boot
 
 RUN git clone https://source.denx.de/u-boot/u-boot.git
- 
+
 WORKDIR /u-boot
- 
+
 RUN git checkout v2023.01 && \
     make nanopi-r2s-rk3328_defconfig
 
@@ -89,8 +89,8 @@ RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
 };
 EOF
 
-RUN sed -i 's|u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;|u-boot,spl-boot-order = "same-as-spl", \&spi0, \&sdmmc;|' \
-    arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+RUN sed -i.bak 's|u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;|u-boot,spl-boot-order = "same-as-spl", \&spi0, \&sdmmc;|' \
+    arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi && (! diff arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi.bak &> /dev/null)
 
 RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s.dts
 &spi0 {
@@ -110,9 +110,11 @@ RUN <<EOF cat >> drivers/spi/rk_spi.c
 DM_DRIVER_ALIAS(rockchip_rk3288_spi, rockchip_rk3328_spi);
 EOF
 
-RUN sed -i 's|[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|[BROM_BOOTSOURCE_SPINOR] "/spi@ff190000", [BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|' arch/arm/mach-rockchip/rk3328/rk3328.c
+RUN sed -i.bak 's|\[BROM_BOOTSOURCE_EMMC\] = "/mmc@ff520000",|[BROM_BOOTSOURCE_SPINOR] "/spi@ff190000", [BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",|' \
+    arch/arm/mach-rockchip/rk3328/rk3328.c && (! diff arch/arm/mach-rockchip/rk3328/rk3328.c arch/arm/mach-rockchip/rk3328/rk3328.c.bak)
 
-RUN sed -i 's|uclass_get_device_by_of_offset(UCLASS_SPI_FLASH|uclass_get_device_by_of_offset(UCLASS_SPI|g' arch/arm/mach-rockchip/spl-boot-order.c
+RUN sed -i.bak 's|uclass_get_device_by_of_offset(UCLASS_SPI_FLASH|uclass_get_device_by_of_offset(UCLASS_SPI|g' \
+    arch/arm/mach-rockchip/spl-boot-order.c && (! diff arch/arm/mach-rockchip/spl-boot-order.c arch/arm/mach-rockchip/spl-boot-order.c.bak)
 
 COPY --from=trust /arm-trusted-firmware/build/rk3328/release/bl31/bl31.elf /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
 };
 EOF
 
-RUN sed -i.bak 's|u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;|u-boot,spl-boot-order = "same-as-spl", \&spi0, \&sdmmc;|' \
+RUN sed -i.bak 's|u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;|u-boot,spl-boot-order = "same-as-spl", \&sdmmc, \&spi_flash;|' \
     arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi && (! diff arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi.bak &> /dev/null)
 
 RUN <<EOF cat >> arch/arm/dts/rk3328-nanopi-r2s.dts

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN ./tools/mkimage -n rk3328 -T rksd -d tpl/u-boot-tpl.bin idbloader.img
 #COPY uboot_debug.patch /uboot_debug.patch
 #RUN patch -p1 < /uboot_debug.patch
 
-RUN make CROSS_COMPILE=aarch64-linux-gnu- u-boot.itb
+RUN BL31=/bl31.elf make CROSS_COMPILE=aarch64-linux-gnu- u-boot.itb
 
 ###############################################################################
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ cat zero32k.bin > idb_finish.img
 cat newidb.img >> idb_finish.img
 ```
 
+6. Write `u-boot.itb` again, because on SD card it will be searched for at block 16384:
+
+```
+dd if=u-boot.itb of=idb_finish.img bs=512 seek=16384
+```
+
 The resulting image is prepared in file `idb_finish.img`.
 
 Write the SPI image to the SPI Flash chip

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Note: above will work, but limits access to only first 16Mb of 32Mb SPI Flash.
 Configure and patch files of the mainline U-boot
 ================================================
 
-1. Download latest U-Boot from https://github.com/u-boot/u-boot
+1. Download latest U-Boot from https://github.com/u-boot/u-boot and switch into to a some well-working release branch:
 
 ```
-git clone --depth 1 https://source.denx.de/u-boot/u-boot.git
+git clone https://source.denx.de/u-boot/u-boot.git
 cd u-boot
+git checkout v2023.01
 ```
 
 2. Compile ARM Trusted Platform for RK3328

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ chosen {
 8. Fix RockChip SPI Driver `drivers/spi/rk_spi.c` and add at the end:
 
 ```
-DM_DRIVER_ALIAS(rockchip_rk3288_spi, rockchip_rk3328_spi);
+DM_DRIVER_ALIAS(rockchip_rk3288_spi, rockchip_rk3328_spi)
 ```
 
 9. Fix boot device in Uboot RK3328 code:

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ CONFIG_ROCKCHIP_SPI=y
 };
 ```
 
-* Edit the same file and add &spi0 node to boot-order:
+* Edit the same file and add &spi_flash node to boot-order (put it last, if you want to allow recovery from SD card):
 
 ```
 chosen {
-	u-boot,spl-boot-order = "same-as-spl", &spi0, &sdmmc;
+    u-boot,spl-boot-order = "same-as-spl", &sdmmc, &spi_flash;
 };
 ```
 

--- a/uboot_debug.patch
+++ b/uboot_debug.patch
@@ -1,0 +1,13 @@
+diff --git a/include/common.h b/include/common.h
+index 25c317f443..ee7daaeaef 100644
+--- a/include/common.h
++++ b/include/common.h
+@@ -12,6 +12,8 @@
+ #ifndef __COMMON_H_
+ #define __COMMON_H_	1
+ 
++#define LOG_DEBUG
++
+ #ifndef __ASSEMBLY__		/* put C only stuff in this section */
+ #include <config.h>
+ #include <errno.h>


### PR DESCRIPTION
Hi @MarcinWad ,

This PR ensures proper U-boot image generation, both manual and automatic via Docker. The following issues have been fixed:

1. Write u-boot.itb again at sector 16384 to get booting from SD card to work, see #3 
2. Some minor improvements in the README file
3. Fix broken build with Docker: missing dot in `.config`, missing BL31 env
4. U-boot version is set to v2023.01

You may want to re-generate release based on this update.